### PR TITLE
Graceful shutdown package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/indiependente/pkg
+
+go 1.13
+
+require golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/shutdown/shutdown.go
+++ b/shutdown/shutdown.go
@@ -1,0 +1,53 @@
+package shutdown
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type TerminationFn func(context.Context) error
+
+// Wait allows the service to wait for a termination signal, start the cancellation process by calling
+// the context.CancelFunc in order to perform a graceful service shutdown executing the TerminationFn in input.
+func Wait(ctx context.Context, cancel context.CancelFunc, termFn TerminationFn, logger logger) error {
+	var (
+		gracefulStop = make(chan os.Signal, 1)
+		eg           errgroup.Group
+	)
+
+	// Get notified for incoming signals
+	signal.Notify(gracefulStop, syscall.SIGTERM)
+	signal.Notify(gracefulStop, syscall.SIGINT)
+
+	// Start termination goroutine
+	eg.Go(func() error {
+		<-ctx.Done() // Wait for context cancellation
+		return termFn(ctx)
+	})
+
+	// Wait for signal
+	sig := <-gracefulStop
+	logger.Event("shutdown").Signal(sig).Info("Starting graceful shutdown process")
+
+	// Propagate context cancelling
+	cancel()
+
+	// Wait for cancellation propagation and termination operations to stop
+	err := eg.Wait()
+	if err != nil {
+		return fmt.Errorf("could not terminate gracefully: %w", err)
+	}
+
+	return nil
+}
+
+type logger interface {
+	Event(string) logger
+	Signal(os.Signal) logger
+	Info(string)
+}

--- a/shutdown/shutdown.go
+++ b/shutdown/shutdown.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// TerminationFn is a callback invoked on context cancellation.
 type TerminationFn func(context.Context) error
 
 // Wait allows the service to wait for a termination signal, start the cancellation process by calling


### PR DESCRIPTION
This package exposes a single function `Wait`:

`Wait` allows the service to wait for a termination signal, start the cancellation process by the `context.CancelFunc` in order to perform a graceful service shutdown executing the `TerminationFn` in input.